### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/lynstanford/d3b5097c-3446-4022-bfca-3cee97f230e5/c476ec00-3912-49b2-9020-080bb67dd15a/_apis/work/boardbadge/8bb491d1-28d5-43a6-aa0d-676200cf2e74)](https://dev.azure.com/lynstanford/d3b5097c-3446-4022-bfca-3cee97f230e5/_boards/board/t/c476ec00-3912-49b2-9020-080bb67dd15a/Microsoft.RequirementCategory)
 # machine-learning
 A variety of Machine Learning and Deep Learning models for my web site portfolio using SciKit Learn, PyTorch, TensorFlow and Keras.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/lynstanford/d3b5097c-3446-4022-bfca-3cee97f230e5/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.